### PR TITLE
Remove 'toy_' prefix in name of some form fields

### DIFF
--- a/knpu/episode1/Challenges/FilesJsonBooleans/ReadFileJsonDecodeCoding.php
+++ b/knpu/episode1/Challenges/FilesJsonBooleans/ReadFileJsonDecodeCoding.php
@@ -45,15 +45,15 @@ EOF
 [
     {
         "name": "Bacon Bone",
-        "toy_color": "Bacon-colored"
+        "color": "Bacon-colored"
     },
     {
         "name": "Tennis Ball",
-        "toy_color": "Yellow"
+        "color": "Yellow"
     },
     {
         "name": "Frisbee",
-        "toy_color": "Red"
+        "color": "Red"
     }
 ]
 EOF
@@ -92,7 +92,7 @@ EOF
 
 <?php foreach (\$toys as \$toy) { ?>
     <h3><?php echo \$toy['name']; ?></h3>
-    <h4><?php echo \$toy['toy_color']; ?></h4>
+    <h4><?php echo \$toy['color']; ?></h4>
 <?php } ?>
 EOF
         );

--- a/knpu/episode2/Challenges/CleaningUpWithSavedPets/RefactorToySavingCoding.php
+++ b/knpu/episode2/Challenges/CleaningUpWithSavedPets/RefactorToySavingCoding.php
@@ -43,7 +43,7 @@ file_put_contents('toys.json', \$json);
 ?>
 
 <form action="/new_toy.php" method="POST">
-    <input type="text" name="toy_name" />
+    <input type="text" name="name" />
     <textarea name="description"></textarea>
 
     <button type="submit">Add toy</button>
@@ -121,7 +121,7 @@ save_toys(\$toys);
 ?>
 
 <form action="/new_toy.php" method="POST">
-    <input type="text" name="toy_name" />
+    <input type="text" name="name" />
     <textarea name="description"></textarea>
 
     <button type="submit">Add toy</button>

--- a/knpu/episode2/Challenges/CreateForm/CreateHtmlFormCoding.php
+++ b/knpu/episode2/Challenges/CreateForm/CreateHtmlFormCoding.php
@@ -22,7 +22,7 @@ class CreateHtmlFormCoding implements CodingChallengeInterface
 The pet toy business is *so* popular that we're becoming the Etsy of dog toys:
 allowing other people to post their own vintage, organic, vegan toys on our
 site to sell. Create an HTML form that submits a POST request to `/new_toy.php`
-and give it 2 fields: an input text field called `toy_name` and a `textarea` field
+and give it 2 fields: an input text field called `name` and a `textarea` field
 called `description`:
 
 EOF;
@@ -69,8 +69,8 @@ EOF
         }
 
         $form = $crawler->form();
-        if (!$form->has('toy_name')) {
-            throw new GradingException('I don\'t see any field with `name="toy_name"`');
+        if (!$form->has('name')) {
+            throw new GradingException('I don\'t see any field with `name="name"`');
         }
         if (!$form->has('description')) {
             throw new GradingException('I don\'t see any field with `name="description"`');
@@ -82,7 +82,7 @@ EOF
         $correctAnswer
             ->setFileContents('new_toy.php', <<<EOF
 <form action="/new_toy.php" method="POST">
-    <input type="text" name="toy_name" />
+    <input type="text" name="name" />
     <textarea name="description"></textarea>
 
     <button type="submit">Add toy</button>

--- a/knpu/episode2/Challenges/ReadingFormData/CheckHttpMethodCoding.php
+++ b/knpu/episode2/Challenges/ReadingFormData/CheckHttpMethodCoding.php
@@ -42,7 +42,7 @@ var_dump(\$name, \$description);
 ?>
 
 <form action="/new_toy.php" method="POST">
-    <input type="text" name="toy_name" />
+    <input type="text" name="name" />
     <textarea name="description"></textarea>
 
     <button type="submit">Add toy</button>
@@ -87,7 +87,7 @@ if (\$_SERVER['REQUEST_METHOD'] == 'POST') {
 ?>
 
 <form action="/new_toy.php" method="POST">
-    <input type="text" name="toy_name" />
+    <input type="text" name="name" />
     <textarea name="description"></textarea>
 
     <button type="submit">Add toy</button>

--- a/knpu/episode2/Challenges/ReadingFormData/FetchPOSTDataCoding.php
+++ b/knpu/episode2/Challenges/ReadingFormData/FetchPOSTDataCoding.php
@@ -38,7 +38,7 @@ EOF;
 <!-- set variables and var_dump() up here -->
 
 <form action="/new_toy.php" method="POST">
-    <input type="text" name="toy_name" />
+    <input type="text" name="name" />
     <textarea name="description"></textarea>
 
     <button type="submit">Add toy</button>
@@ -86,7 +86,7 @@ var_dump(\$name, \$description);
 ?>
 
 <form action="/new_toy.php" method="POST">
-    <input type="text" name="toy_name" />
+    <input type="text" name="name" />
     <textarea name="description"></textarea>
 
     <button type="submit">Add toy</button>

--- a/knpu/episode2/Challenges/SavingPets/FormSubmitLogicCoding.php
+++ b/knpu/episode2/Challenges/SavingPets/FormSubmitLogicCoding.php
@@ -41,7 +41,7 @@ require 'functions.php';
 ?>
 
 <form action="/new_toy.php" method="POST">
-    <input type="text" name="toy_name" />
+    <input type="text" name="name" />
     <textarea name="description"></textarea>
 
     <button type="submit">Add toy</button>
@@ -129,7 +129,7 @@ var_dump(file_get_contents('toys.json'));
 ?>
 
 <form action="/new_toy.php" method="POST">
-    <input type="text" name="toy_name" />
+    <input type="text" name="name" />
     <textarea name="description"></textarea>
 
     <button type="submit">Add toy</button>


### PR DESCRIPTION
I think we can make name simpler removing `toy_` prefix.

According to Gilron's suggestion on [knpuniversity.uservoice.com](http://knpuniversity.uservoice.com/forums/143666--how-can-we-improve-knpuniversity/suggestions/11181741-error-in-challenge).